### PR TITLE
Handle empty SA Corp lists by collecting errors

### DIFF
--- a/Prod Run 1.0.7
+++ b/Prod Run 1.0.7
@@ -306,6 +306,12 @@
           await waitProceedWithErrorWatch('');
 
           stat.textContent = 'Returning to Items tab'; await clickItems(); if (abort) return; await sleep(CUSHION);
+        } else {
+          stat.textContent = 'Click Proceed to continue';
+          btnProc.disabled = false;
+          await waitProceedWithErrorWatch('');
+
+          stat.textContent = 'Returning to Items tab'; await clickItems(); if (abort) return; await sleep(CUSHION);
         }
       }
       if (!abort) {


### PR DESCRIPTION
## Summary
- collect errors even when SA corp list is empty by mirroring proceed path

## Testing
- `node --check /tmp/prod-run.js && echo "Syntax OK"`

------
https://chatgpt.com/codex/tasks/task_e_68c0934c950483289a8ee278bed49b1a